### PR TITLE
fix: collisione di tag immagine Docker tra stack dev e produzione

### DIFF
--- a/docker-compose.prod.yml
+++ b/docker-compose.prod.yml
@@ -6,9 +6,13 @@
 # CORS_ALLOWED_ORIGINS, CSRF_TRUSTED_ORIGINS (vedi secrets/secrets.example.txt).
 #
 # Uso: docker compose -f docker-compose.prod.yml up --build
+#
+# NOTA: usa lo stesso host/porta 8000 di docker-compose.yml (dev) per django -
+# non avviare i due stack insieme, andrebbero in conflitto sulla porta.
 
 services:
   django:
+    image: itscompanypw-django-prod
     build:
       context: .
       dockerfile: Dockerfile.prod
@@ -23,6 +27,7 @@ services:
       - app_network
 
   angular:
+    image: itscompanypw-angular-prod
     build:
       context: ./Frontend/FrontendResources
       dockerfile: Dockerfile.prod


### PR DESCRIPTION
## Riepilogo
docker-compose.yml (dev) e docker-compose.prod.yml calcolavano lo stesso tag immagine di default (stessi nomi servizio, stessa directory). Buildare lo stack di produzione sovrascriveva il tag usato dallo stack dev, facendo partire il container dev con l'immagine Nginx invece di `ng serve` — sintomo: `localhost:4200` restituiva pagina vuota nonostante il container risultasse "up".

## Fix
Nomi immagine espliciti e distinti in docker-compose.prod.yml (`itscompanypw-django-prod`, `itscompanypw-angular-prod`).

## Test plan
- [x] Riprodotto il bug, confermata la causa (`docker inspect` mostrava `Cmd: nginx` sul container dev)
- [x] Applicato il fix, ricostruita l'immagine prod con i nuovi tag, verificato che il tag dev resti quello corretto e che `localhost:4200` torni a rispondere 200